### PR TITLE
Quitada la referencia al id del template

### DIFF
--- a/resources/assets/js/components/select-category.vue
+++ b/resources/assets/js/components/select-category.vue
@@ -9,7 +9,6 @@
 
 <script>
 export default {
-    template: "#select_category_tpl",
     props: ['categories', 'id']
 }
 </script>


### PR DESCRIPTION
Dado que ahora se trabaja con un archivo .vue, no es necesario nombrar el id del template que usa el componente; además dicho id ya se había borrado de la etiqueta template.
